### PR TITLE
fixed this really annoying thing on the readme where you say from twice

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,5 @@
 ## Piston
-Piston is the underlying engine for running untrusted and possibly malicious code that originates
-from from EMKC contests and challenges. It's also used in the Engineer Man Discord server via
+Piston is the underlying engine for running untrusted and possibly malicious code that originates from EMKC contests and challenges. It's also used in the Engineer Man Discord server via
 [felix bot](https://github.com/engineer-man/felix).
 
 #### Installation


### PR DESCRIPTION
so at the top of the read me it says 

> that originates **from from** EMKC 

I changed it to say

> that originates **from** EMKC 
