### PR TITLE
Add awk support

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -63,6 +63,7 @@ func Execute(res http.ResponseWriter, req *http.Request) {
         "brainfuck", "bf",
         "rust",
         "bash",
+        "awk",
     }
 
     // check if the supplied language is supported

--- a/lxc/executors/awk
+++ b/lxc/executors/awk
@@ -1,0 +1,5 @@
+cd /tmp/$2
+timeout -s KILL 2 sed "/___code___/Q" code.code > code.stdin
+timeout -s KILL 2 sed "1,/___code___/d" code.code > code.awk
+timeout -s KILL 3 awk -f code.awk < code.stdin
+runuser -l runner$1 -c "cd /tmp/$2 ; timeout -s KILL 3 awk -f code.awk < code.stdin"


### PR DESCRIPTION
Adds basic awk support. Uses a `___code___` seperator to seperate stdin and code itself.