### PR TITLE
add support for elisp scripts

### DIFF
--- a/lxc/execute
+++ b/lxc/execute
@@ -87,6 +87,9 @@ case "$lang" in
 "rust")
     bin=rust
     ;;
+"elisp" | "el")
+    bin=emacs
+    ;;
 "bash")
     bin=bash
     ;;

--- a/lxc/executors/emacs
+++ b/lxc/executors/emacs
@@ -1,0 +1,2 @@
+cd /tmp/$2
+runuser -l runner$1 -c "cd /tmp/$2 ; cat args.args | xargs -d '\n' timeout -s KILL 3 emacs -Q --script code.code"

--- a/tests/test.el
+++ b/tests/test.el
@@ -1,0 +1,1 @@
+(message "good")


### PR DESCRIPTION
Hi EM,
I tried to add support for executing elisp scripts through `emacs`.
This code is untested and it was written by studying what was already there.
Your server will need `emacs` installed in order for it to work.

Let me know if I did anything wrong!