### PR TITLE
Add "lisp" as an alias for "elisp" and "el"

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -71,7 +71,7 @@ func Execute(res http.ResponseWriter, req *http.Request) {
         "cpp", "c++",
         "csharp", "cs", "c#",
         "elixir", "exs",
-        "emacs", "elisp", "el",
+        "emacs", "elisp", "el", "lisp",
         "go",
         "java",
         "julia", "jl",
@@ -142,7 +142,7 @@ func launch(request Inbound, res http.ResponseWriter) {
         execlang = "cpp"
     case "cs", "c#":
         execlang = "csharp"
-    case "el", "elisp":
+    case "el", "elisp", "lisp":
         execlang = "emacs"
     case "exs":
         execlang = "elixir"

--- a/lxc/execute
+++ b/lxc/execute
@@ -99,7 +99,7 @@ case "$lang" in
 "swift")
     bin=swift
     ;;
-"emacs" | "elisp" | "el")
+"emacs" | "elisp" | "el" | "lisp")
     bin=emacs
     ;;
 "bash")


### PR DESCRIPTION
This patch adds the `lisp` alias when invoking Felix to run Elisp code. I hadn't thought about this in my first PR but this allows to use:
````lisp
```lisp
    (message "Hello, World!")
```
````
and make use of Discord's syntax highlighting feature.