### PR TITLE
Running executors as runner users

### DIFF
--- a/lxc/execute
+++ b/lxc/execute
@@ -48,7 +48,7 @@ lxc-attach --clear-env -n piston -- \
 # runner
 timeout -s KILL 20 \
     lxc-attach --clear-env -n piston -- \
-        /bin/bash -l -c "bash /exec/$lang $newinc $epoch"
+        /bin/bash -l -c "runuser runner$newinc -c 'bash /exec/$lang $epoch'"
 
 # process janitor
 lxc-attach --clear-env -n piston -- \

--- a/lxc/execute
+++ b/lxc/execute
@@ -36,6 +36,15 @@ else
 fi
 exec 200>&-
 
+# Prevent users from spying on each other
+lxc-attach --clear-env -n piston -- \
+        /bin/bash -l -c "\
+                chown runner$newinc: $filepath ;\
+                chown runner$newinc: $argpath ;\
+                chmod 700 $filepath ;\
+                chmod 700 $argpath ;\
+               " > /dev/null 2>&1
+
 # runner
 timeout -s KILL 20 \
     lxc-attach --clear-env -n piston -- \

--- a/lxc/executors/awk
+++ b/lxc/executors/awk
@@ -1,4 +1,4 @@
-cd /tmp/$2
+cd /tmp/$1
 timeout -s KILL 2 sed "/___code___/Q" code.code > code.stdin
 timeout -s KILL 2 sed "1,/___code___/d" code.code > code.awk
-runuser runner$1 -c "cd /tmp/$2 ; timeout -s KILL 3 awk -f code.awk < code.stdin"
+cd /tmp/$1 ; timeout -s KILL 3 awk -f code.awk < code.stdin

--- a/lxc/executors/bash
+++ b/lxc/executors/bash
@@ -1,2 +1,1 @@
-cd /tmp/$2
-runuser runner$1 -c "cd /tmp/$2 ; cat args.args | xargs -d '\n' timeout -s KILL 3 bash code.code"
+cd /tmp/$1 ; cat args.args | xargs -d '\n' timeout -s KILL 3 bash code.code

--- a/lxc/executors/brainfuck
+++ b/lxc/executors/brainfuck
@@ -1,2 +1,1 @@
-cd /tmp/$2
-runuser runner$1 -c "cd /tmp/$2 ; cat args.args | xargs -d '\n' timeout -s KILL 3 brainfuck code.code"
+cd /tmp/$1 ; cat args.args | xargs -d '\n' timeout -s KILL 3 brainfuck code.code

--- a/lxc/executors/c
+++ b/lxc/executors/c
@@ -1,4 +1,3 @@
-runuser runner$1 -c "\
-    cd /tmp/$2 ; \
-    gcc -std=c11 -o binary -x c code.code ; \
-    cat args.args | xargs -d '\n' timeout -s KILL 3 ./binary"
+cd /tmp/$1 ;
+gcc -std=c11 -o binary -x c code.code ;
+cat args.args | xargs -d '\n' timeout -s KILL 3 ./binary

--- a/lxc/executors/cpp
+++ b/lxc/executors/cpp
@@ -1,4 +1,3 @@
-runuser runner$1 -c "\
-    cd /tmp/$2 ; \
-    g++ -std=c++17 -o binary -x c++ code.code ; \
-    cat args.args | xargs -d '\n' timeout -s KILL 3 ./binary"
+cd /tmp/$1 ;
+g++ -std=c++17 -o binary -x c++ code.code ;
+cat args.args | xargs -d '\n' timeout -s KILL 3 ./binary

--- a/lxc/executors/csharp
+++ b/lxc/executors/csharp
@@ -1,4 +1,3 @@
-runuser runner$1 -c "\
-    cd /tmp/$2 ; \
-    mcs $(echo code.code | sed 's/\///') -nowarn:0219 -out:binary ; \
-    cat args.args | xargs -d '\n' timeout -s KILL 3 mono binary"
+cd /tmp/$1 ;
+mcs $(echo code.code | sed 's/\///') -nowarn:0219 -out:binary ;
+cat args.args | xargs -d '\n' timeout -s KILL 3 mono binary

--- a/lxc/executors/deno
+++ b/lxc/executors/deno
@@ -1,7 +1,7 @@
-cd /tmp/$2
+cd /tmp/$1
 
 if [[ -z $(grep '[^[:space:]]' args.args) ]]; then
-    runuser runner$1 -c "cd /tmp/$2 ; timeout -s KILL 3 deno run code.code"
+    cd /tmp/$1 ; timeout -s KILL 3 deno run code.code
 else
-    runuser runner$1 -c "cd /tmp/$2 ; cat args.args | xargs -d '\n' timeout -s KILL 3 deno run code.code"
+    cd /tmp/$1 ; cat args.args | xargs -d '\n' timeout -s KILL 3 deno run code.code
 fi

--- a/lxc/executors/elixir
+++ b/lxc/executors/elixir
@@ -1,7 +1,7 @@
-cd /tmp/$2
+cd /tmp/$1
 
 if [[ -z $(grep '[^[:space:]]' args.args) ]]; then
-    runuser runner$1 -c "cd /tmp/$2 ; timeout -s KILL 3 elixir code.code"
+    cd /tmp/$1 ; timeout -s KILL 3 elixir code.code
 else
-    runuser runner$1 -c "cd /tmp/$2 ; cat args.args ; xargs -d '\n' timeout -s KILL 3 elixir code.code"
+    cd /tmp/$1 ; cat args.args ; xargs -d '\n' timeout -s KILL 3 elixir code.code
 fi

--- a/lxc/executors/emacs
+++ b/lxc/executors/emacs
@@ -1,7 +1,7 @@
-cd /tmp/$2
+cd /tmp/$1
 
 if [[ -z $(grep '[^[:space:]]' args.args) ]]; then
-    runuser runner$1 -c "cd /tmp/$2 ; timeout -s KILL 3 emacs -Q --script code.code"
+    cd /tmp/$1 ; timeout -s KILL 3 emacs -Q --script code.code
 else
-    runuser runner$1 -c "cd /tmp/$2 ; cat args.args | xargs -d '\n' timeout -s KILL 3 emacs -Q --script code.code"
+    cd /tmp/$1 ; cat args.args | xargs -d '\n' timeout -s KILL 3 emacs -Q --script code.code
 fi

--- a/lxc/executors/go
+++ b/lxc/executors/go
@@ -1,6 +1,6 @@
-cd /tmp/$2
+cd /tmp/$1
 cp code.code interim.go
 file="interim.go"
 go build $file
 file=${file%%.*}
-runuser runner$1 -c "cd /tmp/$2 ; cat args.args | xargs -d '\n' timeout -s KILL 3 ./$file"
+cd /tmp/$1 ; cat args.args | xargs -d '\n' timeout -s KILL 3 ./$file

--- a/lxc/executors/haskell
+++ b/lxc/executors/haskell
@@ -1,7 +1,4 @@
-cd /tmp/$2
-mv code.code code.hs
-
-runuser runner$1 -c "\
-    cd /tmp/$2 ; \
-    ghc -dynamic -o binary code.hs > /dev/null 2>&1 ; \
-    cat args.args | xargs -d '\n' timeout -s KILL 3 ./binary"
+cd /tmp/$1
+mv code.code code.hs ;
+ghc -dynamic -o binary code.hs > /dev/null 2>&1 ;
+cat args.args | xargs -d '\n' timeout -s KILL 3 ./binary

--- a/lxc/executors/java
+++ b/lxc/executors/java
@@ -1,9 +1,8 @@
-cd /tmp/$2
+cd /tmp/$1
 cp code.code interim.java
 name=$(grep -Po "(?<=\n|\A)\s*(public\s+)?(class|interface)\s+\K([^\/\\\n\s{]+)" interim.java)
 mv interim.java $name.java
 
-runuser runner$1 -c "\
-    cd /tmp/$2 ; \
-    javac $name.java ; \
-    cat args.args | xargs -d '\n' timeout -s KILL 3 java $name"
+cd /tmp/$1 ;
+javac $name.java ;
+cat args.args | xargs -d '\n' timeout -s KILL 3 java $name

--- a/lxc/executors/jelly
+++ b/lxc/executors/jelly
@@ -1,2 +1,1 @@
-cd /tmp/$2
-runuser runner$1 -c "cd /tmp/$2 ; cat args.args | xargs -d '\n' timeout -s KILL 3 jelly fu code.code"
+cd /tmp/$1 ; cat args.args | xargs -d '\n' timeout -s KILL 3 jelly fu code.code

--- a/lxc/executors/julia
+++ b/lxc/executors/julia
@@ -1,2 +1,1 @@
-cd /tmp/$2
-runuser runner$1 -c "cd /tmp/$2 ; cat args.args | xargs -d '\n' timeout -s KILL 3 julia code.code"
+cd /tmp/$1 ; cat args.args | xargs -d '\n' timeout -s KILL 3 julia code.code

--- a/lxc/executors/kotlin
+++ b/lxc/executors/kotlin
@@ -1,6 +1,4 @@
-cd /tmp/$2
+cd /tmp/$1
 cp code.code code.kt
-runuser runner$1 -c "\
-    cd /tmp/$2 ; \
-    kotlinc code.kt -include-runtime -d code.jar ; \
-    cat args.args | xargs -d '\n' timeout -s KILL 3 java -jar code.jar"
+kotlinc code.kt -include-runtime -d code.jar ;
+cat args.args | xargs -d '\n' timeout -s KILL 3 java -jar code.jar

--- a/lxc/executors/lua
+++ b/lxc/executors/lua
@@ -1,2 +1,1 @@
-cd /tmp/$2
-runuser runner$1 -c "cd /tmp/$2 ; cat args.args | xargs -d '\n' timeout -s KILL 3 lua code.code"
+cd /tmp/$1 ; cat args.args | xargs -d '\n' timeout -s KILL 3 lua code.code

--- a/lxc/executors/nasm
+++ b/lxc/executors/nasm
@@ -1,5 +1,4 @@
-runuser runner$1 -c "\
-    cd /tmp/$2 ; \
-    nasm -f elf32 -o binary.o code.code ; \
-    ld -m elf_i386 binary.o -o binary ; \
-    cat args.args | xargs -d '\n' timeout -s KILL 3 ./binary"
+cd /tmp/$1 ;
+nasm -f elf32 -o binary.o code.code ;
+ld -m elf_i386 binary.o -o binary ;
+cat args.args | xargs -d '\n' timeout -s KILL 3 ./binary

--- a/lxc/executors/nasm64
+++ b/lxc/executors/nasm64
@@ -1,5 +1,4 @@
-runuser runner$1 -c "\
-    cd /tmp/$2 ; \
-    nasm -f elf64 -o binary.o code.code ; \
-    ld -m elf_x86_64 binary.o -o binary ; \
-    cat args.args | xargs -d '\n' timeout -s KILL 3 ./binary"
+cd /tmp/$1 ;
+nasm -f elf64 -o binary.o code.code ;
+ld -m elf_x86_64 binary.o -o binary ;
+cat args.args | xargs -d '\n' timeout -s KILL 3 ./binary

--- a/lxc/executors/node
+++ b/lxc/executors/node
@@ -1,7 +1,7 @@
-cd /tmp/$2
+cd /tmp/$1
 
 if [[ -z $(grep '[^[:space:]]' args.args) ]]; then
-    runuser runner$1 -c "cd /tmp/$2 ; timeout -s KILL 3 node code.code"
+    cd /tmp/$1 ; timeout -s KILL 3 node code.code
 else
-    runuser runner$1 -c "cd /tmp/$2 ; cat args.args | xargs -d '\n' timeout -s KILL 3 node code.code"
+    cd /tmp/$1 ; cat args.args | xargs -d '\n' timeout -s KILL 3 node code.code
 fi

--- a/lxc/executors/paradoc
+++ b/lxc/executors/paradoc
@@ -1,2 +1,1 @@
-cd /tmp/$2
-runuser runner$1 -c "cd /tmp/$2 ; timeout -s KILL 3 python3 -m paradoc code.code <<< args.args"
+cd /tmp/$1 ; timeout -s KILL 3 python3 -m paradoc code.code <<< args.args

--- a/lxc/executors/perl
+++ b/lxc/executors/perl
@@ -1,2 +1,1 @@
-cd /tmp/$2
-runuser runner$1 -c "cd /tmp/$2 ; cat args.args | xargs -d '\n' timeout -s KILL 3 perl code.code"
+cd /tmp/$1 ; cat args.args | xargs -d '\n' timeout -s KILL 3 perl code.code

--- a/lxc/executors/php
+++ b/lxc/executors/php
@@ -1,2 +1,1 @@
-cd /tmp/$2
-runuser runner$1 -c "cd /tmp/$2 ; cat args.args | xargs -d '\n' timeout -s KILL 3 php code.code"
+cd /tmp/$1 ; cat args.args | xargs -d '\n' timeout -s KILL 3 php code.code

--- a/lxc/executors/python2
+++ b/lxc/executors/python2
@@ -1,2 +1,1 @@
-cd /tmp/$2
-runuser runner$1 -c "cd /tmp/$2 ; cat args.args | xargs -d '\n' timeout -s KILL 3 python code.code"
+cd /tmp/$1 ; cat args.args | xargs -d '\n' timeout -s KILL 3 python code.code

--- a/lxc/executors/python3
+++ b/lxc/executors/python3
@@ -1,2 +1,1 @@
-cd /tmp/$2
-runuser runner$1 -c "cd /tmp/$2 ; cat args.args | xargs -d '\n' timeout -s KILL 3 python3.8 code.code"
+cd /tmp/$1 ; cat args.args | xargs -d '\n' timeout -s KILL 3 python3.8 code.code

--- a/lxc/executors/ruby
+++ b/lxc/executors/ruby
@@ -1,2 +1,1 @@
-cd /tmp/$2
-runuser runner$1 -c "cd /tmp/$2 ; cat args.args | xargs -d '\n' timeout -s KILL 3 ruby code.code"
+cd /tmp/$1 ; cat args.args | xargs -d '\n' timeout -s KILL 3 ruby code.code

--- a/lxc/executors/rust
+++ b/lxc/executors/rust
@@ -1,5 +1,3 @@
-cd /tmp/$2
+cd /tmp/$1
 rustc -o binary code.code
-runuser runner$1 -c "\
-    cd /tmp/$2 ; \
-    cat args.args | xargs -d '\n' timeout -s KILL 3 ./binary"
+cat args.args | xargs -d '\n' timeout -s KILL 3 ./binary

--- a/lxc/executors/swift
+++ b/lxc/executors/swift
@@ -1,2 +1,1 @@
-cd /tmp/$2
-runuser runner$1 -c "cd /tmp/$2 ; cat args.args | xargs -d '\n' timeout -s KILL 3 swift code.code"
+cd /tmp/$1 ; cat args.args | xargs -d '\n' timeout -s KILL 3 swift code.code

--- a/lxc/executors/typescript
+++ b/lxc/executors/typescript
@@ -1,7 +1,6 @@
-runuser runner$1 -c "\
-    cd /tmp/$2 ; \
-    mv code.code interim.ts ; \
-    tsc interim.ts ; \
-    rm -f interim.ts ; \
-    mv interim.js code.code ; \
-    cat args.args | xargs -d '\n' timeout -s KILL 3 node code.code"
+cd /tmp/$1 ;
+mv code.code interim.ts ;
+tsc interim.ts ;
+rm -f interim.ts ;
+mv interim.js code.code ;
+cat args.args | xargs -d '\n' timeout -s KILL 3 node code.code

--- a/lxc/start
+++ b/lxc/start
@@ -3,7 +3,7 @@
 mkdir -p /var/lib/lxc/piston/rootfs/exec
 rm -f /var/lib/lxc/piston/rootfs/exec/*
 cp -f executors/* /var/lib/lxc/piston/rootfs/exec
-chmod 700 /var/lib/lxc/piston/rootfs/exec/*
+chmod 705 /var/lib/lxc/piston/rootfs/exec/*
 chown -R root:root /var/lib/lxc/piston/rootfs/exec
 
 lxc-start -n piston -d


### PR DESCRIPTION
Running executors as runner users to prevent a user from running anything under root privilege level.
Also, chmod and chowning users code to prevent users from "spying" on each other and intentionally getting secret inputs from engineering man contests.
This should mean that nim can be added back to the piston.