### PR TITLE
Prevent users from spying on each other

### DIFF
--- a/lxc/execute
+++ b/lxc/execute
@@ -37,7 +37,12 @@ else
     echo $newinc > $dir/i
 fi
 exec 200>&-
-
+# Prevent users from spying on each other
+lxc-attach --clear-env -n piston -- \
+	/bin/bash -l -c "\
+		chown runner$newinc: -R /tmp/$epoch ;\
+		chmod 700 /tmp/$epoch ;\
+		" > /dev/null 2>&1
 # runner
 timeout -s KILL 20 \
     lxc-attach --clear-env -n piston -- \


### PR DESCRIPTION
Preventing the user from spying on each other currently running code by chmoding and chowning runner folder so only the current runner can read from it.
Should not anyhow effect piston functionality.