### PR TITLE
Run Java directly to avoid grep

### DIFF
--- a/lxc/executors/java
+++ b/lxc/executors/java
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-cd /tmp/$2
-name=$(grep -Po "(?<=\n|\A)\s*(public\s+)?(class|interface)\s+\K([^\/\\\\\n\s{]+)" code.code)
-cp code.code $name.java
-javac $name.java
-timeout -s KILL 3 xargs -a args.args -d '\n' java $name < stdin.stdin
+cp code.code interim.java
+timeout -s KILL 10 xargs -a args.args -d '\n' java interim.java < stdin.stdin
+


### PR DESCRIPTION
It should work better than grep. Works on interfaces and such. My only concern is the timeout, since compilation and execution are combined.