### PR TITLE
Disable color output for deno

### DIFF
--- a/lxc/executors/deno
+++ b/lxc/executors/deno
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cd /tmp/$1
-timeout -s KILL 3 xargs -a args.args -d '\n' deno run code.code < stdin.stdin
+timeout -s KILL 3 xargs -a args.args -d '\n' NO_COLOR=true deno run code.code < stdin.stdin


### PR DESCRIPTION
By default Deno has color output, we don't need this - and it also makes challenges on emkc.org not give the correct results.