### PR TITLE
call main\1 predicate with arguments list if any

### DIFF
--- a/lxc/executors/prolog
+++ b/lxc/executors/prolog
@@ -5,4 +5,9 @@ cd /tmp/$1
 sed 's/^.*$/:- forall((Goal = (\0), call(Goal)), (write(Goal), nl))./' stdin.stdin |
     cat code.code - > code.pl
 
+if [ -s args.args ]
+then
+    echo ":- main($(jq --raw-input -c --slurp 'split("\n")' args.args))." >> code.pl
+fi
+
 timeout -s KILL 3 swipl -g true -t halt code.pl


### PR DESCRIPTION
This PR gives command line arguments access to prolog programs via the main/1 predicate which accepts one list argument.
This predicate should be defined whenever arguments are given.