### PR TITLE
Disable color output for scala

### DIFF
--- a/lxc/executors/scala
+++ b/lxc/executors/scala
@@ -2,4 +2,4 @@
 
 cd /tmp/$1
 cp code.code interim.scala
-timeout -s KILL 10 xargs -a args.args -d '\n' scala interim.scala < stdin.stdin
+timeout -s KILL 10 xargs -a args.args -d '\n' scala -color never interim.scala < stdin.stdin


### PR DESCRIPTION
Scala has colored compiler errors on by default which can't be rendered in places like the piston bot and causes compiler errors to become a big mess and makes it difficult to figure out what actually happened.