### PR TITLE
Fix scala version

### DIFF
--- a/container/install_script.sh
+++ b/container/install_script.sh
@@ -101,7 +101,7 @@ cd rust-1.49.0-x86_64-unknown-linux-gnu
 
 # install scala
 # final binary: /opt/scala/scala3-3.0.0-M3/bin/scala
-# get version: /opt/scala/scala3-3.0.0-M3/bin/scala -version
+# get version: /opt/scala/scala3-3.0.0-M3/bin/scalac -version
 cd /opt && mkdir scala && cd scala
 wget https://github.com/lampepfl/dotty/releases/download/3.0.0-M3/scala3-3.0.0-M3.tar.gz
 tar -xzf scala3-3.0.0-M3.tar.gz

--- a/lxc/util/versions
+++ b/lxc/util/versions
@@ -130,7 +130,7 @@ lxc-attach --clear-env -n piston -- /bin/bash -l -c "rustc --version"
 echo '---'
 
 echo 'scala'
-lxc-attach --clear-env -n piston -- /bin/bash -l -c "scala -version"
+lxc-attach --clear-env -n piston -- /bin/bash -l -c "scalac -version"
 echo '---'
 
 echo 'swift'


### PR DESCRIPTION
Right now the scala version script invokes `scala` which starts the repl when it should actually ask `scalac` for the version.