### PR TITLE
Fix package init script to use "$@" in run file instead of "$*"

### DIFF
--- a/packages/init
+++ b/packages/init
@@ -54,7 +54,7 @@ echo "# Put 'export' statements here for environment variables" >> environment
 echo "export PATH=\$PWD/bin:\$PATH" >> environment
 
 echo "# Put instructions to run the runtime" >> run
-echo "$NAME-$VERSION \$*" >> run
+echo "$NAME-$VERSION \"\$@\"" >> run
 
 echo "# Put instructions to compile source code, remove this file if the language does not require this stage" >> compile
 


### PR DESCRIPTION
Fix the v3 package init script to insert "$@" in run file.