### PR TITLE
pkg(rust-1.50.0): Add rust 1.50.0

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -5,7 +5,7 @@ RUN for i in $(seq 1001 1500); do \
         useradd -M runner$i -g $i -u $i ; \
     done
 RUN apt-get update && \
-    apt-get install -y libxml2 gnupg tar coreutils util-linux libc6-dev binutils build-essential && \
+    apt-get install -y libxml2 gnupg tar coreutils util-linux libc6-dev binutils && \
     rm -rf /var/lib/apt/lists/*
 
 ENV NODE_ENV=production

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -5,7 +5,7 @@ RUN for i in $(seq 1001 1500); do \
         useradd -M runner$i -g $i -u $i ; \
     done
 RUN apt-get update && \
-    apt-get install -y libxml2 gnupg tar coreutils util-linux libc6-dev binutils && \
+    apt-get install -y libxml2 gnupg tar coreutils util-linux libc6-dev binutils build-essential && \
     rm -rf /var/lib/apt/lists/*
 
 ENV NODE_ENV=production

--- a/packages/rust/1.50.0/build.sh
+++ b/packages/rust/1.50.0/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+curl -OL "https://static.rust-lang.org/dist/rust-1.50.0-x86_64-unknown-linux-gnu.tar.gz"
+tar xzvf rust-1.50.0-x86_64-unknown-linux-gnu.tar.gz
+rm rust-1.50.0-x86_64-unknown-linux-gnu.tar.gz

--- a/packages/rust/1.50.0/compile
+++ b/packages/rust/1.50.0/compile
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# https://stackoverflow.com/questions/38041331/rust-compiler-cant-find-crate-for-std
+# Rust compiler needs to find the stdlib to link against
+rustc -o binary -L ${RUST_INSTALL_LOC}/rustc/lib -L ${RUST_INSTALL_LOC}/rust-std-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib "$@"
+chmod +x binary

--- a/packages/rust/1.50.0/environment
+++ b/packages/rust/1.50.0/environment
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Put 'export' statements here for environment variables
+export PATH=$PWD/rust-1.50.0-x86_64-unknown-linux-gnu/rustc/bin/:$PATH
+export RUST_INSTALL_LOC=$PWD/rust-1.50.0-x86_64-unknown-linux-gnu

--- a/packages/rust/1.50.0/metadata.json
+++ b/packages/rust/1.50.0/metadata.json
@@ -1,0 +1,6 @@
+{
+  "language": "rust",
+  "version": "1.50.0",
+  "aliases": ["rs"],
+  "author": "Victor Frazao <luiz_victor_frazao@hotmail.com>"
+}

--- a/packages/rust/1.50.0/run
+++ b/packages/rust/1.50.0/run
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+./binary "$@"

--- a/packages/rust/1.50.0/test.rs
+++ b/packages/rust/1.50.0/test.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("OK");
+}


### PR DESCRIPTION
Adds rust to v3. Needs build-essential in API container because `rustc` uses `cc` for linking. You can specify ld (pass `-C linker=ld` to rustc) to link, but linking still fails since ld can't find `gcc_s`. 