### PR TITLE
Add build-essential V3 API container 

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -5,7 +5,7 @@ RUN for i in $(seq 1001 1500); do \
         useradd -M runner$i -g $i -u $i ; \
     done
 RUN apt-get update && \
-    apt-get install -y libxml2 gnupg tar coreutils util-linux libc6-dev binutils && \
+    apt-get install -y libxml2 gnupg tar coreutils util-linux libc6-dev binutils build-essential && \
     rm -rf /var/lib/apt/lists/*
 
 ENV NODE_ENV=production


### PR DESCRIPTION
Adds build-essential V3 API  container. Rust executor needs `cc` and libgcc_s in order to compile binaries.