### PR TITLE
pkg(rust-1.50.0): Fix run file to remove filename from being passed to binary

### DIFF
--- a/packages/rust/1.50.0/run
+++ b/packages/rust/1.50.0/run
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
+shift
 ./binary "$@"


### PR DESCRIPTION
pkg(rust-1.50.0): Fix run file to remove filename from being passed to binary

Needed to `shift` before running binary.