### PR TITLE
Added max_memory_usage parameter

### DIFF
--- a/api/src/api/v2.js
+++ b/api/src/api/v2.js
@@ -1,13 +1,14 @@
 const express = require('express');
 const router  = express.Router();
 
+const config = require('../config');
 const runtime = require('../runtime');
 const {Job} = require("../job");
 const package = require('../package')
 const logger = require('logplease').create('api/v1');
 
 router.post('/execute', async function(req, res){
-        const {language, version, files, stdin, args, run_timeout, compile_timeout} = req.body;
+        const {language, version, files, stdin, args, run_timeout, compile_timeout, max_memory_usage} = req.body;
 
         if(!language || typeof language !== "string")
         {
@@ -46,6 +47,21 @@ router.post('/execute', async function(req, res){
             }
         }
 
+        if (max_memory_usage) {
+            if (typeof max_memory_usage !== "number" || max_memory_usage < 0) {
+                return res
+                    .status(400)
+                    .send({
+                        message: "if specified, max_memory_usage must be a non-negative number"
+                    })
+            } else if (max_memory_usage > config.max_memory_usage) {
+                return res
+                    .status(400)
+                    .send({
+                        message: "max_memory_usage cannot exceed the configured limit of " + config.max_memory_usage
+                    })
+            }
+        }
 
 
     
@@ -68,7 +84,8 @@ router.post('/execute', async function(req, res){
             timeouts: {
                 run: run_timeout || 3000,
                 compile: compile_timeout || 10000
-            }
+            },
+            max_memory_usage: max_memory_usage || config.max_memory_usage
         });
 
         await job.prime();

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -109,6 +109,12 @@ const options = [
         validators: []
     },
     {
+        key: 'max_memory_usage',
+        desc: 'Max memory usage in bytes',
+        default: 256000000, //256MB
+        validators: []
+    },
+    {
         key: 'repo_url',
         desc: 'URL of repo index',
         default: 'https://github.com/engineer-man/piston/releases/download/pkgs/index',

--- a/readme.md
+++ b/readme.md
@@ -210,6 +210,7 @@ This endpoint requests execution of some arbitrary code.
 - `args` (*optional*) The arguments to pass to the program. Must be an array or left out. Defaults to `[]`.
 - `compile_timeout` (*optional*) The maximum time allowed for the compile stage to finish before bailing out in milliseconds. Must be a number or left out. Defaults to `10000` (10 seconds).
 - `run_timeout` (*optional*) The maximum time allowed for the run stage to finish before bailing out in milliseconds. Must be a number or left out. Defaults to `3000` (3 seconds).
+- `max_memory_usage` (*optional*) The maximum amount of memory the run stage is allowed to use. Must be a number or left out. Defaults to `256000000` (256 MB)
 
 ```json
 {
@@ -228,7 +229,8 @@ This endpoint requests execution of some arbitrary code.
         "3"
     ],
     "compile_timeout": 10000,
-    "run_timeout": 3000
+    "run_timeout": 3000,
+    "max_memory_usage": 256000000
 }
 ```
 A typical response upon successful execution will contain 1 or 2 keys `run` and `compile`.


### PR DESCRIPTION
Added an optional `max_memory_usage` parameter to limit the amount of memory a job is allowed to use. The default value and upper limit can be configured in `config.yaml`.