### PR TITLE
pkg(octave-6.2.0): add deps for octave

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -10,7 +10,10 @@ RUN for i in $(seq 1001 1500); do \
 RUN apt-get update && \
     apt-get install -y libxml2 gnupg tar coreutils util-linux libc6-dev \
     binutils build-essential locales libpcre3-dev libevent-dev libgmp3-dev \
-    libncurses6 libncurses5 libedit-dev libseccomp-dev rename procps python3 && \
+    libncurses6 libncurses5 libedit-dev libseccomp-dev rename procps python3 \
+    libreadline-dev libblas-dev liblapack-dev libpcre3-dev libarpack2-dev \
+    libfftw3-dev libglpk-dev libqhull-dev libqrupdate-dev libsuitesparse-dev \
+    libsundials-dev && \
     rm -rf /var/lib/apt/lists/*
 
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen

--- a/repo/Dockerfile
+++ b/repo/Dockerfile
@@ -6,8 +6,9 @@ RUN apt-get update && apt-get install -y unzip autoconf build-essential libssl-d
         linux-headers-amd64 perl xz-utils python3 python3-pip gnupg jq zlib1g-dev \
         cmake cmake-doc extra-cmake-modules build-essential gcc binutils bash coreutils \
         util-linux pciutils usbutils coreutils binutils findutils grep libncurses5-dev \
-        libncursesw5-dev python3-pip libgmp-dev libmpfr-dev python2 libffi-dev \
-        libreadline-dev && \
+        libncursesw5-dev python3-pip libgmp-dev libmpfr-dev python2 libffi-dev gfortran\
+        libreadline-dev libblas-dev liblapack-dev libpcre3-dev libarpack2-dev libfftw3-dev \
+        libglpk-dev libqhull-dev libqrupdate-dev libsuitesparse-dev libsundials-dev && \
         ln -sf /bin/bash /bin/sh && \
         rm -rf /var/lib/apt/lists/* && \
         update-alternatives --install /usr/bin/python python /usr/bin/python3.7 2


### PR DESCRIPTION
deps for octave. FYI, this will nearly double the size of the api container. these are all heavy math libs that octave references to do cool math things.

and fortran is needed for building the source only