### PR TITLE
Improved memory limits

### DIFF
--- a/api/src/api/v2.js
+++ b/api/src/api/v2.js
@@ -101,8 +101,10 @@ router.post('/execute', async function(req, res){
                 run: run_timeout || 3000,
                 compile: compile_timeout || 10000
             },
-            compile_memory_limit: compile_memory_limit || config.compile_memory_limit,
-            run_memory_limit: run_memory_limit || config.run_memory_limit
+            memory_limits: {
+                run: run_memory_limit || config.run_memory_limit,
+                compile: compile_memory_limit || config.compile_memory_limit
+            }
         });
 
         await job.prime();

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -109,6 +109,18 @@ const options = [
         validators: []
     },
     {
+        key: 'compile_memory_limit',
+        desc: 'Max memory usage for compile stage in bytes (set to -1 for no limit)',
+        default: -1, // no limit
+        validators: []
+    },
+    {
+        key: 'run_memory_limit',
+        desc: 'Max memory usage for run stage in bytes (set to -1 for no limit)',
+        default: -1, // no limit
+        validators: []
+    },
+    {
         key: 'repo_url',
         desc: 'URL of repo index',
         default: 'https://github.com/engineer-man/piston/releases/download/pkgs/index',

--- a/api/src/job.js
+++ b/api/src/job.js
@@ -19,7 +19,7 @@ let gid = 0;
 
 class Job {
 
-    constructor({ runtime, files, args, stdin, timeouts, compile_memory_limit, run_memory_limit }) {
+    constructor({ runtime, files, args, stdin, timeouts, memory_limits }) {
         this.uuid =  uuidv4();
         this.runtime = runtime;
         this.files = files.map((file,i) => ({
@@ -30,8 +30,7 @@ class Job {
         this.args = args;
         this.stdin = stdin;
         this.timeouts = timeouts;
-        this.compile_memory_limit = compile_memory_limit;
-        this.run_memory_limit = run_memory_limit;
+        this.memory_limits = memory_limits;
 
         this.uid = config.runner_uid_min + uid;
         this.gid = config.runner_gid_min + gid;
@@ -168,7 +167,7 @@ class Job {
                 path.join(this.runtime.pkgdir, 'compile'),
                 this.files.map(x => x.name),
                 this.timeouts.compile,
-                this.compile_memory_limit
+                this.memory_limits.compile
             );
         }
 
@@ -178,7 +177,7 @@ class Job {
             path.join(this.runtime.pkgdir, 'run'),
             [this.files[0].name, ...this.args],
             this.timeouts.run,
-            this.run_memory_limit
+            this.memory_limits.run
         );
 
         this.state = job_states.EXECUTED;

--- a/readme.md
+++ b/readme.md
@@ -210,6 +210,8 @@ This endpoint requests execution of some arbitrary code.
 - `args` (*optional*) The arguments to pass to the program. Must be an array or left out. Defaults to `[]`.
 - `compile_timeout` (*optional*) The maximum time allowed for the compile stage to finish before bailing out in milliseconds. Must be a number or left out. Defaults to `10000` (10 seconds).
 - `run_timeout` (*optional*) The maximum time allowed for the run stage to finish before bailing out in milliseconds. Must be a number or left out. Defaults to `3000` (3 seconds).
+- `compile_memory_limit` (*optional*) The maximum amount of memory the compile stage is allowed to use in bytes. Must be a number or left out. Defaults to `-1` (no limit)
+- `run_memory_limit` (*optional*) The maximum amount of memory the run stage is allowed to use in bytes. Must be a number or left out. Defaults to `-1` (no limit)
 
 ```json
 {
@@ -228,7 +230,9 @@ This endpoint requests execution of some arbitrary code.
         "3"
     ],
     "compile_timeout": 10000,
-    "run_timeout": 3000
+    "run_timeout": 3000,
+    "compile_memory_limit": -1,
+    "run_memory_limit": -1
 }
 ```
 A typical response upon successful execution will contain 1 or 2 keys `run` and `compile`.


### PR DESCRIPTION
Added two independent optional parameters to limit the amount of memory the compile stage and the run stage of a job are allowed to use. The default values and upper limits can be configured in `config.yaml` and default to `-1` (no limit) to avoid any problems when using the default configuration.
