### PR TITLE
zig/0.7.1: set release most to safe so executers can still observe runtime checks

### DIFF
--- a/packages/zig/0.7.1/compile
+++ b/packages/zig/0.7.1/compile
@@ -3,4 +3,4 @@
 # optimizing for small programs
 rename 's/$/\.zig/' "$@" # Add .zig extension
 
-zig build-exe -O ReleaseSmall --color off --cache-dir . --global-cache-dir . --name out *.zig
+zig build-exe -O ReleaseSafe --color off --cache-dir . --global-cache-dir . --name out *.zig


### PR DESCRIPTION
such as the code below which should crash

```zig
var a: u8 = 255;
var b: u8 = 1;
var c: u8 = a + b;
```
