### PR TITLE
Proposal: Add Piston Node.js Client as an Official Extension

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,9 @@ The following are approved and endorsed extensions/utilities to the core Piston 
 
 - [I Run Code](https://github.com/engineer-man/piston-bot), a Discord bot used in 4100+ servers to handle arbitrary code evaluation in Discord. To get this bot in your own server, go here: https://emkc.org/run.
 - [Piston CLI](https://github.com/Shivansh-007/piston-cli), a universal shell supporting code highlighting, files, and interpretation without the need to download a language.
+- [Node Piston Client](https://github.com/dthree/node-piston), a Node.js wrapper for accessing the Piston API.
 
+        
 <br>
 
 # Public API


### PR DESCRIPTION
I created a [Node.js client wrapper](https://github.com/dthree/node-piston) to access the Piston API easily from Node. This makes it very easy to access the public Piston API or any private API from Node, hope you like it!

@realtux I don't mind moving this into the engineer-man account if you'd prefer that.