### PR TITLE
Fixed Go multiple file problem

### DIFF
--- a/packages/go/1.16.2/run
+++ b/packages/go/1.16.2/run
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 mv $1 $1.go
-filename=$1.go
+#filename=$1.go
+filename=*.go
 shift
 GOCACHE=$PWD go run $filename "$@"


### PR DESCRIPTION
When you run a Go project ```go run $1.go``` only compiles and runs $1.go. To compile and run all files in the project we must do ```go run *.go```