### PR TITLE
fix stdin for normal execute

### DIFF
--- a/api/src/api/v2.js
+++ b/api/src/api/v2.js
@@ -106,7 +106,7 @@ function get_job(body){
             runtime: rt,
             alias: language,
             args: args || [],
-            stdin: '',
+            stdin: stdin || "",
             files,
             timeouts: {
                 run: run_timeout || 3000,


### PR DESCRIPTION
I noticed that stdin wasn't working after rebuilding the latest changes locally. This should fix that.

I didn't test the new socket impl tho, since I wasn't able to connect to it on my local instance. @HexF , will this affect your latest web socket additions?