### PR TITLE
added requests library for fun with apis!

### DIFF
--- a/packages/python/3.9.4/build.sh
+++ b/packages/python/3.9.4/build.sh
@@ -18,4 +18,4 @@ cd ..
 
 rm -rf build 
 
-bin/pip3 install numpy scipy pandas pycrypto whoosh bcrypt passlib sympy
+bin/pip3 install numpy scipy pandas pycrypto whoosh bcrypt passlib sympy requests


### PR DESCRIPTION
Python requests library is missing.
https://docs.python-requests.org/en/master/user/quickstart/#json-response-content
I believe this change should fix it!

Issue to replicate:
```python
import requests
import json
import random

getDogPic = requests.get('https://dog.ceo/api/breeds/image/random')
dogPic=getDogPic.json()['message']
print(dogPic)
```

Received output:
```
Traceback (most recent call last):
  File "/piston/jobs/5b200eca-dc36-4047-8cb6-a3b5293f111c/file0.code", line 1, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```