### PR TITLE
pkg(freebasic-1.8.0): Add Freebasic

### DIFF
--- a/packages/freebasic/1.8.0/build.sh
+++ b/packages/freebasic/1.8.0/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+curl -L "https://sourceforge.net/projects/fbc/files/FreeBASIC-1.08.0/Binaries-Linux/FreeBASIC-1.08.0-linux-x86_64.tar.gz/download" -o freebasic.tar.gz
+tar xf freebasic.tar.gz --strip-components=1
+rm freebasic.tar.gz

--- a/packages/freebasic/1.8.0/compile
+++ b/packages/freebasic/1.8.0/compile
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Compile bas files
+fbc -lang qb -b "$@" -x out

--- a/packages/freebasic/1.8.0/environment
+++ b/packages/freebasic/1.8.0/environment
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Path to fbc compiler
+export PATH=$PWD/bin:$PATH

--- a/packages/freebasic/1.8.0/metadata.json
+++ b/packages/freebasic/1.8.0/metadata.json
@@ -1,0 +1,5 @@
+{
+    "language": "freebasic",
+    "version": "1.8.0",
+    "aliases": ["bas", "fbc", "basic", "qbasic", "quickbasic"]
+}

--- a/packages/freebasic/1.8.0/run
+++ b/packages/freebasic/1.8.0/run
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Run output file from compile with arguments
+shift
+./out "$@"

--- a/packages/freebasic/1.8.0/test.bas
+++ b/packages/freebasic/1.8.0/test.bas
@@ -1,0 +1,1 @@
+PRINT "OK"

--- a/readme.md
+++ b/readme.md
@@ -339,6 +339,7 @@ Content-Type: application/json
 `emacs`,
 `erlang`,
 `fortran`,
+`freebasic`,
 `go`,
 `golfscript`,
 `groovy`,


### PR DESCRIPTION
This was sitting in another branch too.. just needed to update readme and fix the version.

QBasic is DOS only. FreeBASIC is its successor and works on linux. I've set the compiler flags to compile QBasic programs.

fixes #288 