### PR TITLE
prevent building empty package on pr

### DIFF
--- a/.github/workflows/package-pr.yaml
+++ b/.github/workflows/package-pr.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build Packages
         run: |
-          PACKAGES=$(jq '.[]' -r ${HOME}/files.json | awk -F/ '{ print $2 "-" $3 }' | sort -u)
+          PACKAGES=$(jq '.[]' -r ${HOME}/files.json | awk -F/ '$2 && $3{ print $2 "-" $3 }' | sort -u)
           echo "Packages: $PACKAGES"
           docker pull docker.pkg.github.com/engineer-man/piston/repo-builder:latest
           docker build -t repo-builder repo


### PR DESCRIPTION
I noticed the CI is attempting to build an empty package every time. This checks that both the package name and package version exist before attempting to build it.

**Context**: Hexf found some invalid make commands trying to run. [discord message](https://discord.com/channels/473161189120147456/483979558249562112/893267864923013140)