### PR TITLE
added regex to python 3.9.4

### DIFF
--- a/packages/python/3.9.4/build.sh
+++ b/packages/python/3.9.4/build.sh
@@ -16,6 +16,6 @@ make install -j$(nproc)
 
 cd ..
 
-rm -rf build 
+rm -rf build
 
-bin/pip3 install numpy scipy pandas pycrypto whoosh bcrypt passlib sympy
+bin/pip3 install numpy scipy pandas pycrypto whoosh bcrypt passlib sympy regex


### PR DESCRIPTION
for some reason vyxal requires regex instead of re i think it has a few more features or something btw here is the link to the regex module page https://pypi.org/project/regex/