### PR TITLE
fix pkg build action for when pkg files are deleted

### DIFF
--- a/.github/workflows/package-pr.yaml
+++ b/.github/workflows/package-pr.yaml
@@ -53,7 +53,7 @@ jobs:
 
             - name: Build Packages
               run: |
-                  PACKAGES=$(jq '.[]' -r ${HOME}/files.json | awk -F/ '$2 && $3{ print $2 "-" $3 }' | sort -u)
+                  PACKAGES=$(jq '.[]' -r ${HOME}/files*.json | awk -F/ '$1~/packages/ && $2 && $3{ print $2 "-" $3 }' | sort -u)
                   echo "Packages: $PACKAGES"
                   docker pull docker.pkg.github.com/engineer-man/piston/repo-builder:latest
                   docker build -t repo-builder repo

--- a/.github/workflows/package-push.yaml
+++ b/.github/workflows/package-push.yaml
@@ -30,7 +30,7 @@ jobs:
 
             - name: Build Packages
               run: |
-                  PACKAGES=$(jq '.[]' -r ${HOME}/files.json | awk -F/ '{ print $2 "-" $3 }' | sort -u)
+                  PACKAGES=$(jq '.[]' -r ${HOME}/files*.json | awk -F/ '$1~/packages/ && $2 && $3{ print $2 "-" $3 }' | sort -u)
                   echo "Packages: $PACKAGES"
                   docker pull docker.pkg.github.com/engineer-man/piston/repo-builder:latest
                   docker build -t repo-builder repo


### PR DESCRIPTION
This should fix the case where someone deletes one file from a package and PRs it (e.g. https://github.com/engineer-man/piston/runs/3886968360?check_suite_focus=true#step:5:9).

The actions was not picking up deleted files, which resides only in files_deleted.json instead of files.json. Also added an extra check to make sure we only build packages that get added to the "packages" root folder.