### PR TITLE
add missing libs back into py v3.10

### DIFF
--- a/packages/python/3.10.0/build.sh
+++ b/packages/python/3.10.0/build.sh
@@ -18,3 +18,4 @@ cd ..
 
 rm -rf build
 
+bin/pip3 install numpy scipy pandas pycrypto whoosh bcrypt passlib sympy


### PR DESCRIPTION
add missing libs back into py v3.10 missing from latest version bump (numpy scipy pandas pycrypto whoosh bcrypt passlib sympy)