### PR TITLE
Add piston_rs to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,7 @@ The following are approved and endorsed extensions/utilities to the core Piston 
 -   [Piston4J](https://github.com/the-codeboy/Piston4J), a Java wrapper for accessing the Piston API.
 -   [Pyston](https://github.com/ffaanngg/pyston), a Python wrapper for accessing the Piston API.
 -   [Go-Piston](https://github.com/milindmadhukar/go-piston), a Golang wrapper for accessing the Piston API.
+-   [piston_rs](https://github.com/Jonxslays/piston_rs), a Rust wrapper for accessing the Piston API.
 
 <br>
 


### PR DESCRIPTION
#### Summary

This pull request adds [`piston_rs`](https://github.com/Jonxslays/piston_rs), an async Rust wrapper around the Piston API, to the readme as an officially supported extension.

I used Piston in a few of my bots, and love it. I was perusing the readme and realized there was a new section regarding supported extensions. I also noticed that there was no extension in Rust yet, so I decided to make one. 

- [Crate](https://crates.io/crates/piston_rs)
- [Documentation](https://docs.rs/piston_rs/latest)
- [Repository](https://github.com/Jonxslays/piston_rs)