### PR TITLE
Get rid of file language logic, remove unneeded requires

### DIFF
--- a/api/src/api/v2.js
+++ b/api/src/api/v2.js
@@ -3,7 +3,6 @@ const router = express.Router();
 
 const events = require('events');
 
-const runtime = require('../runtime');
 const { Job } = require('../job');
 
 const SIGNALS = [
@@ -90,10 +89,7 @@ function get_job(body) {
             });
         }
 
-        if (
-            rt.language !== 'file' &&
-            !files.some(file => !file.encoding || file.encoding === 'utf8')
-        ) {
+        if (!files.some(file => !file.encoding || file.encoding === 'utf8')) {
             return reject({
                 message: 'files must include at least one utf8 encoded file',
             });

--- a/api/src/api/v3.js
+++ b/api/src/api/v3.js
@@ -81,10 +81,7 @@ function get_job(body) {
             });
         }
 
-        if (
-            rt.language !== 'file' &&
-            !files.some(file => !file.encoding || file.encoding === 'utf8')
-        ) {
+        if (!files.some(file => !file.encoding || file.encoding === 'utf8')) {
             return reject({
                 message: 'files must include at least one utf8 encoded file',
             });

--- a/api/src/job.js
+++ b/api/src/job.js
@@ -1,5 +1,4 @@
 const logplease = require('logplease');
-const logger = logplease.create('job');
 const { v4: uuidv4 } = require('uuid');
 const cp = require('child_process');
 const path = require('path');
@@ -226,9 +225,7 @@ class Job {
 
         this.logger.info(`Executing job runtime=${this.runtime.toString()}`);
 
-        const code_files =
-            (this.runtime.language === 'file' && this.files) ||
-            this.files.filter(file => file.encoding == 'utf8');
+        const code_files = this.files.filter(file => file.encoding == 'utf8');
 
         this.logger.debug('Compiling');
 
@@ -274,9 +271,7 @@ class Job {
             `Interactively executing job runtime=${this.runtime.toString()}`
         );
 
-        const code_files =
-            (this.runtime.language === 'file' && this.files) ||
-            this.files.filter(file => file.encoding == 'utf8');
+        const code_files = this.files.filter(file => file.encoding == 'utf8');
 
         if (this.runtime.compiled) {
             eventBus.emit('stage', 'compile');


### PR DESCRIPTION
I made this in Piston V3, but I don't think there is a need to add it in Nix Piston. It has a limited use case and it can be replicated on the client side if needed.