### PR TITLE
Revert "build(deps): bump node-fetch from 2.6.1 to 3.1.1 in /api"

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -16,7 +16,7 @@
                 "is-docker": "^2.1.1",
                 "logplease": "^1.2.15",
                 "nocamel": "HexF/nocamel#patch-1",
-                "node-fetch": "^3.1.1",
+                "node-fetch": "^2.6.1",
                 "semver": "^7.3.4",
                 "uuid": "^8.3.2",
                 "waitpid": "git+https://github.com/HexF/node-waitpid.git"
@@ -106,14 +106,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
             "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
-        },
-        "node_modules/data-uri-to-buffer": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-            "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
-            "engines": {
-                "node": ">= 12"
-            }
         },
         "node_modules/debug": {
             "version": "2.6.9",
@@ -216,28 +208,6 @@
                 "express": "^4.0.0 || ^5.0.0-alpha.1"
             }
         },
-        "node_modules/fetch-blob": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.4.tgz",
-            "integrity": "sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/jimmywarting"
-                },
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/jimmywarting"
-                }
-            ],
-            "dependencies": {
-                "node-domexception": "^1.0.0",
-                "web-streams-polyfill": "^3.0.3"
-            },
-            "engines": {
-                "node": "^12.20 || >= 14.13"
-            }
-        },
         "node_modules/finalhandler": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -253,17 +223,6 @@
             },
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/formdata-polyfill": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-            "dependencies": {
-                "fetch-blob": "^3.1.2"
-            },
-            "engines": {
-                "node": ">=12.20.0"
             }
         },
         "node_modules/forwarded": {
@@ -415,39 +374,12 @@
         "node_modules/nocamel": {
             "resolved": "git+ssh://git@github.com/HexF/nocamel.git#89a5bfbbd07c72c302d968b967d0f4fe54846544"
         },
-        "node_modules/node-domexception": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/jimmywarting"
-                },
-                {
-                    "type": "github",
-                    "url": "https://paypal.me/jimmywarting"
-                }
-            ],
-            "engines": {
-                "node": ">=10.5.0"
-            }
-        },
         "node_modules/node-fetch": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.1.1.tgz",
-            "integrity": "sha512-SMk+vKgU77PYotRdWzqZGTZeuFKlsJ0hu4KPviQKkfY+N3vn2MIzr0rvpnYpR8MtB3IEuhlEcuOLbGvLRlA+yg==",
-            "dependencies": {
-                "data-uri-to-buffer": "^4.0.0",
-                "fetch-blob": "^3.1.3",
-                "formdata-polyfill": "^4.0.10"
-            },
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+            "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/node-fetch"
+                "node": "4.x || >=6.0.0"
             }
         },
         "node_modules/on-finished": {
@@ -651,14 +583,6 @@
             "resolved": "git+ssh://git@github.com/HexF/node-waitpid.git#a08d116a5d993a747624fe72ff890167be8c34aa",
             "hasInstallScript": true
         },
-        "node_modules/web-streams-polyfill": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
-            "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
         "node_modules/ws": {
             "version": "7.5.3",
             "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
@@ -750,11 +674,6 @@
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
             "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
         },
-        "data-uri-to-buffer": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-            "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
-        },
         "debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -838,15 +757,6 @@
                 "ws": "^7.4.6"
             }
         },
-        "fetch-blob": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.4.tgz",
-            "integrity": "sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==",
-            "requires": {
-                "node-domexception": "^1.0.0",
-                "web-streams-polyfill": "^3.0.3"
-            }
-        },
         "finalhandler": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -859,14 +769,6 @@
                 "parseurl": "~1.3.3",
                 "statuses": "~1.5.0",
                 "unpipe": "~1.0.0"
-            }
-        },
-        "formdata-polyfill": {
-            "version": "4.0.10",
-            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-            "requires": {
-                "fetch-blob": "^3.1.2"
             }
         },
         "forwarded": {
@@ -974,20 +876,10 @@
             "version": "git+ssh://git@github.com/HexF/nocamel.git#89a5bfbbd07c72c302d968b967d0f4fe54846544",
             "from": "nocamel@HexF/nocamel#patch-1"
         },
-        "node-domexception": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
-        },
         "node-fetch": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.1.1.tgz",
-            "integrity": "sha512-SMk+vKgU77PYotRdWzqZGTZeuFKlsJ0hu4KPviQKkfY+N3vn2MIzr0rvpnYpR8MtB3IEuhlEcuOLbGvLRlA+yg==",
-            "requires": {
-                "data-uri-to-buffer": "^4.0.0",
-                "fetch-blob": "^3.1.3",
-                "formdata-polyfill": "^4.0.10"
-            }
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+            "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "on-finished": {
             "version": "2.3.0",
@@ -1140,11 +1032,6 @@
         "waitpid": {
             "version": "git+ssh://git@github.com/HexF/node-waitpid.git#a08d116a5d993a747624fe72ff890167be8c34aa",
             "from": "waitpid@git+https://github.com/HexF/node-waitpid.git"
-        },
-        "web-streams-polyfill": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
-            "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA=="
         },
         "ws": {
             "version": "7.5.3",

--- a/api/package.json
+++ b/api/package.json
@@ -11,7 +11,7 @@
         "is-docker": "^2.1.1",
         "logplease": "^1.2.15",
         "nocamel": "HexF/nocamel#patch-1",
-        "node-fetch": "^3.1.1",
+        "node-fetch": "^2.6.1",
         "semver": "^7.3.4",
         "uuid": "^8.3.2",
         "waitpid": "git+https://github.com/HexF/node-waitpid.git"


### PR DESCRIPTION
Reverts engineer-man/piston#426

This upgrade introduced a breaking API change, which the code hasn't been adjusted for. In the mean time will will revert it.

More info: https://github.com/engineer-man/piston/commit/c3678b9bce1c63a6ad957dd40534d619dab584bd#r67700144
