### PR TITLE
add python 3.11.0b1 alpha (Unable to test)

### DIFF
--- a/packages/python/3.11.0b1/build.sh
+++ b/packages/python/3.11.0b1/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+PREFIX=$(realpath $(dirname $0))
+
+mkdir -p build
+
+cd build
+
+curl "https://www.python.org/ftp/python/3.11.0/Python-3.11.0b1.tgz" -o python.tar.gz
+tar xzf python.tar.gz --strip-components=1
+rm python.tar.gz
+
+./configure --prefix "$PREFIX" --with-ensurepip=install
+make -j$(nproc)
+make install -j$(nproc)
+
+cd ..
+
+rm -rf build
+
+# This is alpha version, hence most of the libraries are not compatible with python3.11.0b1
+# bin/pip3 install numpy scipy pandas pycrypto whoosh bcrypt passlib sympy

--- a/packages/python/3.11.0b1/environment
+++ b/packages/python/3.11.0b1/environment
@@ -1,0 +1,1 @@
+export PATH=$PWD/bin:$PATH

--- a/packages/python/3.11.0b1/metadata.json
+++ b/packages/python/3.11.0b1/metadata.json
@@ -1,0 +1,5 @@
+{
+    "language": "python",
+    "version": "3.11.0b1",
+    "aliases": ["py", "py3", "python3.11.0b1"]
+}

--- a/packages/python/3.11.0b1/run
+++ b/packages/python/3.11.0b1/run
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python3.11 "$@"

--- a/packages/python/3.11.0b1/test.py
+++ b/packages/python/3.11.0b1/test.py
@@ -1,0 +1,7 @@
+working = True
+
+match working:
+    case True:
+        print("OK")
+    case False:
+        print()


### PR DESCRIPTION
add python 3.11.0b1 alpha version.

Unable to test right now, lmk what or if any changes are needed.