### PR TITLE
pkg(rust-1.62.0): Added rust 1.62.0

### DIFF
--- a/packages/rust/1.62.0/build.sh
+++ b/packages/rust/1.62.0/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+curl -OL "https://static.rust-lang.org/dist/rust-1.62.0-x86_64-unknown-linux-gnu.tar.gz"
+tar xzvf rust-1.62.0-x86_64-unknown-linux-gnu.tar.gz
+rm rust-1.62.0-x86_64-unknown-linux-gnu.tar.gz

--- a/packages/rust/1.62.0/compile
+++ b/packages/rust/1.62.0/compile
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# https://stackoverflow.com/questions/38041331/rust-compiler-cant-find-crate-for-std
+# Rust compiler needs to find the stdlib to link against
+rustc -o binary -L ${RUST_INSTALL_LOC}/rustc/lib -L ${RUST_INSTALL_LOC}/rust-std-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib "$@"
+chmod +x binary

--- a/packages/rust/1.62.0/environment
+++ b/packages/rust/1.62.0/environment
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Put 'export' statements here for environment variables
+export PATH=$PWD/rust-1.62.0-x86_64-unknown-linux-gnu/rustc/bin/:$PATH
+export RUST_INSTALL_LOC=$PWD/rust-1.62.0-x86_64-unknown-linux-gnu

--- a/packages/rust/1.62.0/metadata.json
+++ b/packages/rust/1.62.0/metadata.json
@@ -1,0 +1,7 @@
+{
+    "language": "rust",
+    "version": "1.56.1",
+    "aliases": [
+        "rs"
+    ]
+}

--- a/packages/rust/1.62.0/run
+++ b/packages/rust/1.62.0/run
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+shift
+./binary "$@"

--- a/packages/rust/1.62.0/test.rs
+++ b/packages/rust/1.62.0/test.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("OK");
+}


### PR DESCRIPTION
Following template from #393 to bump the rust toolchain to the latest
stable