### PR TITLE
disable output coloring of deno

### DIFF
--- a/packages/deno/1.16.2/run
+++ b/packages/deno/1.16.2/run
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-DENO_DIR=$PWD deno run $@
+DENO_DIR=$PWD NO_COLOR=true deno run $@

--- a/packages/deno/1.7.5/run
+++ b/packages/deno/1.7.5/run
@@ -1,2 +1,2 @@
 #!/bin/bash
-DENO_DIR=$PWD deno run "$@"
+DENO_DIR=$PWD NO_COLOR=true deno run "$@"


### PR DESCRIPTION
deno's output coloring can cause side effects when we expect plain text. disable coloring of both deno runtimes