### PR TITLE
Improve containers stopping performance by handling SIGTERM (95% improvement)

### DIFF
--- a/api/src/index.js
+++ b/api/src/index.js
@@ -35,7 +35,10 @@ expressWs(app);
             }
         }
     });
-    fss.chmodSync(path.join(config.data_directory, globals.data_directories.jobs), 0o711)
+    fss.chmodSync(
+        path.join(config.data_directory, globals.data_directories.jobs),
+        0o711
+    );
 
     logger.info('Loading packages');
     const pkgdir = path.join(
@@ -92,7 +95,12 @@ expressWs(app);
     logger.debug('Calling app.listen');
     const [address, port] = config.bind_address.split(':');
 
-    app.listen(port, address, () => {
+    const server = app.listen(port, address, () => {
         logger.info('API server started on', config.bind_address);
+    });
+
+    process.on('SIGTERM', () => {
+        server.close();
+        process.exit(0)
     });
 })();

--- a/repo/Dockerfile
+++ b/repo/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y unzip autoconf build-essential libssl-d
         rm -rf /var/lib/apt/lists/* && \
         update-alternatives --install /usr/bin/python python /usr/bin/python3.7 2
 
-ADD entrypoint.sh mkindex.sh /
+ADD entrypoint.sh mkindex.sh serve.py /
 
 ENTRYPOINT ["bash","/entrypoint.sh"]
 CMD ["--no-build"]

--- a/repo/entrypoint.sh
+++ b/repo/entrypoint.sh
@@ -27,7 +27,7 @@ do
             echo "Done with package $pkg"
         elif [[ $CI -eq 1 ]]; then
             echo "Commit SHA: $pkg"
-            
+
             cd ..
             echo "Changed files:"
             git diff --name-only $pkg^1 $pkg
@@ -52,7 +52,7 @@ echo "Index created"
 
 if [[ $SERVER -eq 1 ]]; then
     echo "Starting index server.."
-    python3 -m http.server
+    exec python3 /serve.py
 else
     echo "Skipping starting index server"
 fi

--- a/repo/entrypoint.sh
+++ b/repo/entrypoint.sh
@@ -52,6 +52,7 @@ echo "Index created"
 
 if [[ $SERVER -eq 1 ]]; then
     echo "Starting index server.."
+    # We want the child process to replace the shell to handle signals
     exec python3 /serve.py
 else
     echo "Skipping starting index server"

--- a/repo/serve.py
+++ b/repo/serve.py
@@ -1,0 +1,18 @@
+import signal
+import sys
+import http.server
+import socketserver
+
+PORT = 8000
+
+Handler = http.server.SimpleHTTPRequestHandler
+
+
+def signal_handler(sig, frame):
+    sys.exit(0)
+
+signal.signal(signal.SIGTERM, signal_handler)
+
+with socketserver.TCPServer(("", PORT), Handler) as httpd:
+    print("serving at port", PORT)
+    httpd.serve_forever()


### PR DESCRIPTION
The PID 1 processes in `piston_api` and `piston_repo` containers did not use to handle the `SIGTERM` signal causing Docker to timeout (after about 10 seconds) on stopping the containers and to `SIGKILL` them.

After this change, the containers now stop after about 0.5 seconds on my machine.