### PR TITLE
handle usage stats

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,1 @@
-1. add time format line (https://www.man7.org/linux/man-pages/man1/time.1.html#top_of_page)
+1. ~~add time format line (https://www.man7.org/linux/man-pages/man1/time.1.html#top_of_page)~~

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,1 @@
+1. add time format line (https://www.man7.org/linux/man-pages/man1/time.1.html#top_of_page)

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,8 +4,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN dpkg-reconfigure -p critical dash
 RUN for i in $(seq 1001 1500); do \
-        groupadd -g $i runner$i && \
-        useradd -M runner$i -g $i -u $i ; \
+    groupadd -g $i runner$i && \
+    useradd -M runner$i -g $i -u $i ; \
     done
 RUN apt-get update && \
     apt-get install -y libxml2 gnupg tar coreutils util-linux libc6-dev \
@@ -13,7 +13,7 @@ RUN apt-get update && \
     libncurses6 libncurses5 libedit-dev libseccomp-dev rename procps python3 \
     libreadline-dev libblas-dev liblapack-dev libpcre3-dev libarpack2-dev \
     libfftw3-dev libglpk-dev libqhull-dev libqrupdate-dev libsuitesparse-dev \
-    libsundials-dev libpcre2-dev && \
+    libsundials-dev libpcre2-dev time && \
     rm -rf /var/lib/apt/lists/*
 
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen

--- a/api/package.json
+++ b/api/package.json
@@ -14,8 +14,7 @@
         "node-fetch": "^2.6.1",
         "semver": "^7.3.4",
         "uuid": "^8.3.2",
-        "waitpid": "git+https://github.com/HexF/node-waitpid.git",
-        "pidusage": "^3.0.2"
+        "waitpid": "git+https://github.com/HexF/node-waitpid.git"
     },
     "license": "MIT"
 }

--- a/api/package.json
+++ b/api/package.json
@@ -14,7 +14,8 @@
         "node-fetch": "^2.6.1",
         "semver": "^7.3.4",
         "uuid": "^8.3.2",
-        "waitpid": "git+https://github.com/HexF/node-waitpid.git"
+        "waitpid": "git+https://github.com/HexF/node-waitpid.git",
+        "pidusage": "^3.0.2"
     },
     "license": "MIT"
 }

--- a/api/src/job.js
+++ b/api/src/job.js
@@ -199,6 +199,8 @@ class Job {
             var output = '';
             var stats = [];
 
+            var start_time = new Date().getTime();
+
             const proc = cp.spawn(proc_call[0], proc_call.splice(1), {
                 env: {
                     ...this.runtime.env_vars,
@@ -311,8 +313,11 @@ class Job {
                     stats = stats[stats.length - 1];
                 }
 
+                var end_time = new Date().getTime();
+                var exec_time = end_time - start_time;
+
                 this.logger.debug(`Last stats:`, stats);
-                resolve({ stdout, stderr, code, signal, output, stats });
+                resolve({ stdout, stderr, code, signal, output, stats, exec_time });
             });
 
             proc.on('error', err => {
@@ -323,8 +328,11 @@ class Job {
                     stats = stats[stats.length - 1];
                 }
 
+                var end_time = new Date().getTime();
+                var exec_time = end_time - start_time;
+
                 this.logger.debug(`Last stats:`, stats);
-                reject({ error: err, stdout, stderr, output, stats });
+                reject({ error: err, stdout, stderr, output, stats, exec_time });
             });
         });
     }

--- a/api/src/job.js
+++ b/api/src/job.js
@@ -156,7 +156,9 @@ class Job {
 
             const time_format = [
                 '-f',
-                'real %es\\nuser %Us\\nsys %Ss\\nmem %MKb',
+                // https://www.man7.org/linux/man-pages/man1/time.1.html#top_of_page
+                // elapsed user system memory
+                '%es %Us %Ss %MKb',
             ]
 
             if (memory_limit >= 0) {
@@ -275,10 +277,16 @@ class Job {
                 this.close_cleanup();
 
                 if (stderr.length > 0) {
-                    var stats = stderr.trim().split('\n').slice(-4).join('\n');
+                    var stats = stderr.trim().split('\n').slice(-1).join('\n').split(' ');
 
-                    stderr = stderr.trim().split('\n').slice(0, -4).join('\n');
-                    output = output.trim().split('\n').slice(0, -4).join('\n');
+                    stderr = stderr.trim().split('\n').slice(0, -1).join('\n');
+                    output = output.trim().split('\n').slice(0, -1).join('\n');
+
+                    stats = {
+                        'elapsed_time': stats[0],
+                        'cpu_time': stats[1] + ' / ' + stats[2],
+                        'max_mem': stats[3],
+                    }
                 }
 
                 var end_time = new Date().getTime();
@@ -293,10 +301,16 @@ class Job {
                 this.close_cleanup();
 
                 if (stderr.length > 0) {
-                    var stats = stderr.trim().split('\n').slice(-4).join('\n');
+                    var stats = stderr.trim().split('\n').slice(-1).join('\n').split(' ');
 
-                    stderr = stderr.trim().split('\n').slice(0, -4).join('\n');
-                    output = output.trim().split('\n').slice(0, -4).join('\n');
+                    stderr = stderr.trim().split('\n').slice(0, -1).join('\n');
+                    output = output.trim().split('\n').slice(0, -1).join('\n');
+
+                    stats = {
+                        'elapsed_time': stats[0],
+                        'cpu_time': stats[1] + ' / ' + stats[2],
+                        'max_mem': stats[3],
+                    }
                 }
 
                 var end_time = new Date().getTime();

--- a/api/src/job.js
+++ b/api/src/job.js
@@ -155,7 +155,8 @@ class Job {
             ];
 
             const time_format = [
-                '-p'
+                '-f',
+                'real %es\\nuser %Us\\nsys %Ss\\nmem %MKb',
             ]
 
             if (memory_limit >= 0) {
@@ -274,10 +275,10 @@ class Job {
                 this.close_cleanup();
 
                 if (stderr.length > 0) {
-                    var stats = stderr.trim().split('\n').slice(-3).join('\n');
+                    var stats = stderr.trim().split('\n').slice(-4).join('\n');
 
-                    stderr = stderr.trim().split('\n').slice(0, -3).join('\n');
-                    output = output.trim().split('\n').slice(0, -3).join('\n');
+                    stderr = stderr.trim().split('\n').slice(0, -4).join('\n');
+                    output = output.trim().split('\n').slice(0, -4).join('\n');
                 }
 
                 var end_time = new Date().getTime();
@@ -292,10 +293,10 @@ class Job {
                 this.close_cleanup();
 
                 if (stderr.length > 0) {
-                    var stats = stderr.trim().split('\n').slice(-3).join('\n');
+                    var stats = stderr.trim().split('\n').slice(-4).join('\n');
 
-                    stderr = stderr.trim().split('\n').slice(0, -3).join('\n');
-                    output = output.trim().split('\n').slice(0, -3).join('\n');
+                    stderr = stderr.trim().split('\n').slice(0, -4).join('\n');
+                    output = output.trim().split('\n').slice(0, -4).join('\n');
                 }
 
                 var end_time = new Date().getTime();

--- a/api/src/job.js
+++ b/api/src/job.js
@@ -8,7 +8,6 @@ const globals = require('./globals');
 const fs = require('fs/promises');
 const fss = require('fs');
 const wait_pid = require('waitpid');
-const pidusage = require('pidusage');
 
 const job_states = {
     READY: Symbol('Ready to be primed'),

--- a/api/src/job.js
+++ b/api/src/job.js
@@ -236,9 +236,14 @@ class Job {
             const kill_timeout =
                 (timeout >= 0 &&
                     set_timeout(async _ => {
-                        this.get_stats(proc.pid).then(stat => {
-                            stats.push(stat);
-                        });
+                        try {
+                            this.get_stats(proc.pid).then(stat => {
+                                stats.push(stat);
+                            });
+                        } catch (e) {
+                            this.logger.debug(`Got error while getting stats:`, e);
+                        }
+
                         this.logger.info(`Timeout exceeded timeout=${timeout}`);
                         try {
                             process.kill(proc.pid, 'SIGKILL');

--- a/api/src/job.js
+++ b/api/src/job.js
@@ -144,21 +144,20 @@ class Job {
                 usePs: true,
             }, (err, stat) => {
                 if (err) {
-                    this.logger.error(`Error getting process stats:`, err);
-                    reject(err);
+                    this.logger.debug(`Got error while getting stats:`, err);
+                } else {
+                    let res = {
+                        'cpu': stat.cpu,
+                        'memory': stat.memory,
+                        'ctime': stat.ctime,
+                        'elapsed': stat.elapsed,
+                        'timestamp': stat.timestamp,
+                    };
+
+                    this.logger.debug(`Got stats:`, res);
+
+                    resolve(res);
                 }
-
-                let res = {
-                    'cpu': stat.cpu,
-                    'memory': stat.memory,
-                    'ctime': stat.ctime,
-                    'elapsed': stat.elapsed,
-                    'timestamp': stat.timestamp,
-                };
-
-                this.logger.debug(`Got stats:`, res);
-
-                resolve(res);
             });
         });
     }

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -12,13 +12,14 @@ services:
         volumes:
             - ./data/piston/packages:/piston/packages
         environment:
-            - PISTON_REPO_URL=http://repo:8000/index
+            - PISTON_REPO_URL=https://github.com/engineer-man/piston/releases/download/pkgs/index
         tmpfs:
             - /piston/jobs:exec,uid=1000,gid=1000,mode=711
 
-    repo: # Local testing of packages
+    repo:
+        # Local testing of packages
         build: repo
         container_name: piston_repo
-        command: ['--no-build'] # Don't build anything
+        command: [ '--no-build' ] # Don't build anything
         volumes:
             - .:/piston


### PR DESCRIPTION
An attempt (like a working one) to add getting execution statistics via `time`.
https://www.man7.org/linux/man-pages/man1/time.1.html

Example:
```
{
   "run":{
      "stdout":"hello world\n",
      "stderr":"",
      "code":0,
      "signal":null,
      "output":"hello world",
      "stats":{
         "elapsed_time":"0.20s",      <-- Elapsed real time
         "cpu_time":"0.00s / 0.01s",  <-- Total num of CPU-seconds that the process spent in user/kenrel mode
         "max_mem":"9636Kb"           <-- Max resident set size of the process
      },
      "exec_time":221
   },
   "language":"python",
   "version":"3.12.0"
}
```

