### PR TITLE
Explicitly provide env vars instead of inheriting them from parent

### DIFF
--- a/api/src/job.js
+++ b/api/src/job.js
@@ -158,7 +158,9 @@ class Job {
                 '/box/submission',
                 '-E',
                 'HOME=/tmp',
-                '-e',
+                ...this.runtime.env_vars.flat_map(v => ['-E', v]),
+                '-E',
+                `PISTON_LANGUAGE=${this.runtime.language}`,
                 `--dir=${this.runtime.pkgdir}`,
                 `--dir=/etc:noexec`,
                 `--processes=${this.runtime.max_process_count}`,
@@ -177,10 +179,6 @@ class Job {
                 ...args,
             ],
             {
-                env: {
-                    ...this.runtime.env_vars,
-                    PISTON_LANGUAGE: this.runtime.language,
-                },
                 stdio: 'pipe',
             }
         );

--- a/api/src/runtime.js
+++ b/api/src/runtime.js
@@ -178,15 +178,7 @@ class Runtime {
             const env_file = path.join(this.pkgdir, '.env');
             const env_content = fss.read_file_sync(env_file).toString();
 
-            this._env_vars = {};
-
-            env_content
-                .trim()
-                .split('\n')
-                .map(line => line.split('=', 2))
-                .forEach(([key, val]) => {
-                    this._env_vars[key.trim()] = val.trim();
-                });
+            this._env_vars = env_content.trim().split('\n');
         }
 
         return this._env_vars;


### PR DESCRIPTION
setuid binaries tend to disable variables like `LD_LIBRARY_PATH` to prevent arbitrary code execution with elevated privileges. As a result, `isolate` disables such variables and they are not passed to the process. This leads to problems in runtimes that have such variables in their environment such as gcc.