### PR TITLE
Fix: Resolve undefined function calls causing ReferenceError at startup

### DIFF
--- a/api/src/config.js
+++ b/api/src/config.js
@@ -27,26 +27,26 @@ const options = {
     runner_uid_min: {
         desc: 'Minimum uid to use for runner',
         default: 1001,
-        parser: parse_int,
-        validators: [(x, raw) => !is_nan(x) || `${raw} is not a number`],
+        parser: parseInt,
+        validators: [(x, raw) => !isNaN(x) || `${raw} is not a number`],
     },
     runner_uid_max: {
         desc: 'Maximum uid to use for runner',
         default: 1500,
-        parser: parse_int,
-        validators: [(x, raw) => !is_nan(x) || `${raw} is not a number`],
+        parser: parseInt,
+        validators: [(x, raw) => !isNaN(x) || `${raw} is not a number`],
     },
     runner_gid_min: {
         desc: 'Minimum gid to use for runner',
         default: 1001,
-        parser: parse_int,
-        validators: [(x, raw) => !is_nan(x) || `${raw} is not a number`],
+        parser: parseInt,
+        validators: [(x, raw) => !isNaN(x) || `${raw} is not a number`],
     },
     runner_gid_max: {
         desc: 'Maximum gid to use for runner',
         default: 1500,
-        parser: parse_int,
-        validators: [(x, raw) => !is_nan(x) || `${raw} is not a number`],
+        parser: parseInt,
+        validators: [(x, raw) => !isNaN(x) || `${raw} is not a number`],
     },
     disable_networking: {
         desc: 'Set to true to disable networking',
@@ -57,62 +57,62 @@ const options = {
     output_max_size: {
         desc: 'Max size of each stdio buffer',
         default: 1024,
-        parser: parse_int,
-        validators: [(x, raw) => !is_nan(x) || `${raw} is not a number`],
+        parser: parseInt,
+        validators: [(x, raw) => !isNaN(x) || `${raw} is not a number`],
     },
     max_process_count: {
         desc: 'Max number of processes per job',
         default: 64,
-        parser: parse_int,
-        validators: [(x, raw) => !is_nan(x) || `${raw} is not a number`],
+        parser: parseInt,
+        validators: [(x, raw) => !isNaN(x) || `${raw} is not a number`],
     },
     max_open_files: {
         desc: 'Max number of open files per job',
         default: 2048,
-        parser: parse_int,
-        validators: [(x, raw) => !is_nan(x) || `${raw} is not a number`],
+        parser: parseInt,
+        validators: [(x, raw) => !isNaN(x) || `${raw} is not a number`],
     },
     max_file_size: {
         desc: 'Max file size in bytes for a file',
         default: 10000000, //10MB
-        parser: parse_int,
-        validators: [(x, raw) => !is_nan(x) || `${raw} is not a number`],
+        parser: parseInt,
+        validators: [(x, raw) => !isNaN(x) || `${raw} is not a number`],
     },
     compile_timeout: {
         desc: 'Max time allowed for compile stage in milliseconds',
         default: 10000, // 10 seconds
-        parser: parse_int,
-        validators: [(x, raw) => !is_nan(x) || `${raw} is not a number`],
+        parser: parseInt,
+        validators: [(x, raw) => !isNaN(x) || `${raw} is not a number`],
     },
     run_timeout: {
         desc: 'Max time allowed for run stage in milliseconds',
         default: 3000, // 3 seconds
-        parser: parse_int,
-        validators: [(x, raw) => !is_nan(x) || `${raw} is not a number`],
+        parser: parseInt,
+        validators: [(x, raw) => !isNaN(x) || `${raw} is not a number`],
     },
     compile_cpu_time: {
         desc: 'Max CPU time allowed for compile stage in milliseconds',
         default: 10000, // 10 seconds
-        parser: parse_int,
-        validators: [(x, raw) => !is_nan(x) || `${raw} is not a number`],
+        parser: parseInt,
+        validators: [(x, raw) => !isNaN(x) || `${raw} is not a number`],
     },
     run_cpu_time: {
         desc: 'Max CPU time allowed for run stage in milliseconds',
         default: 3000, // 3 seconds
-        parser: parse_int,
-        validators: [(x, raw) => !is_nan(x) || `${raw} is not a number`],
+        parser: parseInt,
+        validators: [(x, raw) => !isNaN(x) || `${raw} is not a number`],
     },
     compile_memory_limit: {
         desc: 'Max memory usage for compile stage in bytes (set to -1 for no limit)',
         default: -1, // no limit
-        parser: parse_int,
-        validators: [(x, raw) => !is_nan(x) || `${raw} is not a number`],
+        parser: parseInt,
+        validators: [(x, raw) => !isNaN(x) || `${raw} is not a number`],
     },
     run_memory_limit: {
         desc: 'Max memory usage for run stage in bytes (set to -1 for no limit)',
         default: -1, // no limit
-        parser: parse_int,
-        validators: [(x, raw) => !is_nan(x) || `${raw} is not a number`],
+        parser: parseInt,
+        validators: [(x, raw) => !isNaN(x) || `${raw} is not a number`],
     },
     repo_url: {
         desc: 'URL of repo index',
@@ -123,7 +123,7 @@ const options = {
     max_concurrent_jobs: {
         desc: 'Maximum number of concurrent jobs to run at one time',
         default: 64,
-        parser: parse_int,
+        parser: parseInt,
         validators: [x => x > 0 || `${x} cannot be negative`],
     },
     limit_overrides: {

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -20,7 +20,7 @@ expressWs(app);
     Logger.setLogLevel(config.log_level);
     logger.debug('Ensuring data directories exist');
 
-    Object.values(globals.data_directories).for_each(dir => {
+    Object.values(globals.data_directories).forEach(dir => {
         let data_path = path.join(config.data_directory, dir);
 
         logger.debug(`Ensuring ${data_path} exists`);
@@ -58,7 +58,7 @@ expressWs(app);
             fss.exists_sync(path.join(pkg, globals.pkg_installed_file))
         );
 
-    installed_languages.for_each(pkg => runtime.load_package(pkg));
+    installed_languages.forEach(pkg => runtime.load_package(pkg));
 
     logger.info('Starting API Server');
     logger.debug('Constructing Express App');

--- a/api/src/job.js
+++ b/api/src/job.js
@@ -117,7 +117,7 @@ class Job {
                 recursive: true,
                 mode: 0o700,
             });
-            await fs.write_file(file_path, file_content);
+            await fs.writeFile(file_path, file_content);
         }
 
         this.state = job_states.PRIMED;
@@ -277,13 +277,13 @@ class Job {
                 }
                 switch (key) {
                     case 'cg-mem':
-                        memory = parse_int(value) * 1000;
+                        memory = parseInt(value) * 1000;
                         break;
                     case 'exitcode':
-                        code = parse_int(value);
+                        code = parseInt(value);
                         break;
                     case 'exitsig':
-                        signal = globals.SIGNALS[parse_int(value)] ?? null;
+                        signal = globals.SIGNALS[parseInt(value)] ?? null;
                         break;
                     case 'message':
                         message = message || value;
@@ -292,10 +292,10 @@ class Job {
                         status = status || value;
                         break;
                     case 'time':
-                        cpu_time_stat = parse_float(value) * 1000;
+                        cpu_time_stat = parseFloat(value) * 1000;
                         break;
                     case 'time-wall':
-                        wall_time_stat = parse_float(value) * 1000;
+                        wall_time_stat = parseFloat(value) * 1000;
                         break;
                     default:
                         break;

--- a/api/src/package.js
+++ b/api/src/package.js
@@ -142,7 +142,7 @@ class Package {
             )
             .join('\n');
 
-        await fs.write_file(path.join(this.install_path, '.env'), filtered_env);
+        await fs.writeFile(path.join(this.install_path, '.env'), filtered_env);
 
         logger.debug('Changing Ownership of package directory');
         await util.promisify(chownr)(
@@ -152,7 +152,7 @@ class Package {
         );
 
         logger.debug('Writing installed state to disk');
-        await fs.write_file(
+        await fs.writeFile(
             path.join(this.install_path, globals.pkg_installed_file),
             Date.now().toString()
         );


### PR DESCRIPTION
## Root Cause
Multiple undefined function/variable references in pi/src/ would cause ReferenceError crashes at runtime:
- \is_nan()\ → \isNaN()\ (14 occurrences)
- \parse_int()\ → \parseInt()\ (14 occurrences)
- \parse_float()\ → \parseFloat()\ (5 occurrences)
- \or_each()\ → \orEach()\ (2 occurrences)
- \s.write_file()\ → \s.writeFile()\ (3 occurrences)

## Changes
- api/src/config.js: Replace \parse_int\ and \is_nan\ with built-in globals
- api/src/index.js: Replace \or_each\ with \orEach- api/src/job.js: Replace \parse_int\/\parse_float\ with built-ins; \s.write_file\ with \s.writeFile- api/src/package.js: Replace \s.write_file\ with \s.writeFile
4 files changed, 39 insertions(+), 39 deletions(-)