### PR TITLE
configurable `body_parser_json` limit via env

### DIFF
--- a/api/src/config.js
+++ b/api/src/config.js
@@ -24,6 +24,13 @@ const options = {
             x => fss.exists_sync(x) || `Directory ${x} does not exist`,
         ],
     },
+    body_parser_json: {
+        desc: 'Body size limit for JSON requests',
+        default: '100kb', //https://github.com/expressjs/body-parser#limit-2
+        validators: [
+            x => /^\d+(kb|mb|gb)$/i.test(x) || `${x} is not a valid size (e.g. 10mb, 100kb)`,
+        ],
+    },
     runner_uid_min: {
         desc: 'Minimum uid to use for runner',
         default: 1001,

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -65,7 +65,7 @@ expressWs(app);
     logger.debug('Registering middleware');
 
     app.use(body_parser.urlencoded({ extended: true }));
-    app.use(body_parser.json());
+    app.use(body_parser.json({ limit: config.body_parser_json }));
 
     app.use((err, req, res, next) => {
         return res.status(400).send({

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,17 @@ Port and IP address to bind the Piston API to.
 
     This changes the bind address inside the container, and thus serves no purpose when running in a container
 
+## Body Parser JSON Limit
+
+```yaml
+key: PISTON_BODY_PARSER_JSON
+default: 100kb
+```
+
+Maximum size of the JSON request body.
+
+Increase this value if you need to submit large code or arguments (e.g. `10mb`).
+
 ## Data Directory
 
 ```yaml


### PR DESCRIPTION
This will allow us to configure the body_parser_json limit from env. In the context of our project, this is very useful, as it will allow us to configure truly long requests.

Closes: gh-741